### PR TITLE
fix(accessibility): improve links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,13 +66,13 @@ const config = {
           width: 32
         },
         items: [
-          {to: '/blog', label: 'Blog', position: 'left'},
-          {to: 'blog/tags', label: 'Catégories'},
-          {to: 'blog/tags/green', label: 'Green'},
-          {to: 'blog/tags/architecture', label: 'Architecture'},
-          {to: 'blog/tags/cloud', label: 'Cloud'},
-          {to: 'blog/tags/data', label: 'Data & AI'},
-          {to: 'blog/tags/general', label: 'Général'},
+          {to: '/blog', label: 'Blog', position: 'left', exact: true},
+          {to: 'blog/tags', label: 'Catégories', exact: true},
+          {to: 'blog/tags/green', label: 'Green', exact: true},
+          {to: 'blog/tags/architecture', label: 'Architecture', exact: true},
+          {to: 'blog/tags/cloud', label: 'Cloud', exact: true},
+          {to: 'blog/tags/data', label: 'Data & AI', exact: true},
+          {to: 'blog/tags/general', label: 'Général', exact: true},
           // Future categories, one post is required to display the tem navigation bar, if not, build fail
           /*{
             type: 'dropdown',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -78,3 +78,7 @@
   color: #0e11a8;
   border-radius: 0px 0.3em 0.3em 0px;
 }
+
+.navbar__link:hover, .navbar__link--active {
+  text-decoration: underline;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,6 +79,8 @@
   border-radius: 0px 0.3em 0.3em 0px;
 }
 
+/* Accessibility improvements */
+
 .navbar__link:hover, .navbar__link--active, article a {
   text-decoration: underline;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,6 +79,6 @@
   border-radius: 0px 0.3em 0.3em 0px;
 }
 
-.navbar__link:hover, .navbar__link--active {
+.navbar__link:hover, .navbar__link--active, article a {
   text-decoration: underline;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -84,3 +84,7 @@
 .navbar__link:hover, .navbar__link--active, article a {
   text-decoration: underline;
 }
+
+div[class^='authorSocials'] {
+  overflow: inherit;
+}


### PR DESCRIPTION
:warning: Visible changes: titles are underlined in menu and in articles, please check that the style is ok.

Fixes accessibility errors:
- 3.1: Selected menu is not only differentiated by color
- 10.6: Links in article texts are not only differentiated by color

Improves:
- 10.7: Focus on social icons in author header were partially visible, now fully displayed (test: use tab focus)

Bugfix:
- Multiple menus selected when subtree pages are selected (eg: Blog, Categories and Green menus are all selected when I am on page /blog/tags/green).