### PR TITLE
ci: skip Firebase preview deploy when secret is unavailable

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,6 +15,11 @@ concurrency:
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest
+    # Expose the secret as a job-level env var so it can be tested in step `if`
+    # conditions. Secrets are not available to workflows triggered by Dependabot
+    # or forks, so this is empty there and the deploy step is skipped (not failed).
+    env:
+      FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ZATSIT_BLOG }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,8 +29,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      # The build above is the blocking check. The preview deploy only runs when
+      # the Firebase secret is present, so Dependabot/fork PRs stay green.
+      - name: Deploy preview to Firebase Hosting
+        if: ${{ env.FIREBASE_SERVICE_ACCOUNT != '' }}
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ZATSIT_BLOG }}'
+          firebaseServiceAccount: '${{ env.FIREBASE_SERVICE_ACCOUNT }}'
           projectId: zatsit-blog


### PR DESCRIPTION
## Problème

Le check `build_and_preview` échoue sur **toutes** les PRs Dependabot (et de forks). GitHub n'expose pas les secrets du dépôt aux workflows déclenchés par Dependabot, donc l'étape `FirebaseExtended/action-hosting-deploy` plante sur un `firebaseServiceAccount` vide et fait échouer tout le job — alors que le build, lui, passe.

## Correctif

- Le secret est mappé sur une variable d'env au niveau du job (`FIREBASE_SERVICE_ACCOUNT`), ce qui permet de le tester dans un `if` d'étape.
- L'étape de déploiement preview est conditionnée à la présence du secret : elle est **skippée** (et non en échec) quand il est absent.
- Le **build reste le check bloquant** et reste représentatif sur les PRs Dependabot.

## Effet attendu

Les PRs Dependabot repassent au vert après un `@dependabot rebase` (pour qu'elles récupèrent ce workflow corrigé). Aucun changement de comportement sur les PRs internes qui disposent du secret : le preview continue de se déployer.