### PR TITLE
ci(deps): narrow Dependabot scope for React and 0.x packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: build(deps)
+    ignore:
+      # React is driven by Docusaurus, which is pinned to React 18. A major bump
+      # here breaks the build, so let Docusaurus lead and drop these PRs.
+      - dependency-name: react
+        update-types:
+          - version-update:semver-major
+      - dependency-name: react-dom
+        update-types:
+          - version-update:semver-major
     groups:
       # Group minor and patch bumps into a single PR: these dependencies are all
       # transitive (pulled by Docusaurus) and only touch package-lock.json, so
@@ -16,6 +25,13 @@ updates:
         update-types:
           - minor
           - patch
+        exclude-patterns:
+          # 0.x packages: semver calls a 0.x bump a minor, but upstream treats it
+          # as a major and may break. Keep them out of the group so each lands in
+          # its own reviewable PR. Both render user-visible output (math formulas,
+          # carbon badge). Remove from this list once they reach 1.0.
+          - "@tgwf/co2"
+          - katex
     # Major bumps stay in their own PR: they need a manual review of the changelog.
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
Follow-up to #72. Adding `.github/dependabot.yml` there enabled **version updates**, which this repository never had: only security updates were running, and those need no config file. The first scan therefore opened 4 PRs (#73, #74, #75, #76), two of which are not actionable as-is.

## Changes

**Ignore major bumps of `react` / `react-dom`.** #75 and #76 bump React 18.2 to 19.2 and fail CI in 10 seconds: Docusaurus 3.9 builds against React 18. The version is dictated by Docusaurus, so these PRs can only ever be red until Docusaurus itself moves. Both are closed alongside this PR.

**Exclude `@tgwf/co2` and `katex` from the `npm-minor-patch` group.** #74 grouped `@tgwf/co2` 0.14 to 0.19 and `katex` 0.16 to 0.18 as minor bumps. Semver says minor, upstream treats a `0.x` bump as a major, and both packages render user-visible output (math formulas, carbon badge). They now land in their own reviewable PR. The comment notes they should be removed from the exclusion list once they reach 1.0.

## Not changed

The grouping itself works as intended: without it, #74 alone would have been 4 separate PRs. Majors keep their own PR for manual changelog review.

## Note on #74

Left open on purpose. Its CI is green but the KaTeX and co2 bumps warrant a look at the preview (a page with math formulas, and the carbon badge) before merging. Once this PR is merged, Dependabot will rebuild #74 without those two packages on its next run.